### PR TITLE
Fix install duma.3 in GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -485,7 +485,7 @@ ifdef DUMASO_LINK2
 	ln -s $(DUMASO) $(DESTDIR)$(libdir)/$(DUMASO_LINK2)
 endif
 	- mkdir -p $(DESTDIR)$(MAN_INSTALL_DIR)
-	$(INSTALL) -m 644 duma.3 $(DESTDIR)/$(MAN_INSTALL_DIR)/duma.3
+	$(INSTALL) -m 644 duma.3 $(DESTDIR)$(MAN_INSTALL_DIR)/duma.3
 
 # Delete all the installed files that the `install' target would create
 uninstall:


### PR DESCRIPTION
When i try to build toolchain using crosstool-ng 1.25.0 in cygwin, 
DUMA build is failed.

I found mistake at GNUmakefile in VERSION_2_5_21

Fortunately, the problem did not occur in ubuntu, 
but the problem occurred in cygwin.

Here is error log about the issue

[ALL  ]    mkdir -p /home/ABC/x-tools/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/debug-root/usr/share/man/man3
[ALL  ]    install -m 644 duma.3 //home/ABC/x-tools/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/debug-root/usr/share/man/man3/duma.3
[ALL  ]    /usr/bin/install: cannot create regular file '//home/ABC/x-tools/arm-unknown-linux-gnueabi/arm-unknown-linux-gnueabi/debug-root/usr/share/man/man3/duma.3': No such file or directory

Sorry about my first poor PR

Signed-off-by: yyb39miku [yyb39miku@gmail.com]
