### PR TITLE
malloc_usable_size: Add implementation of the function

### DIFF
--- a/duma.h
+++ b/duma.h
@@ -263,6 +263,8 @@ DUMA_EXTERN_C int _duma_posix_memalign(void **memptr, size_t alignment,
 DUMA_EXTERN_C void *_duma_realloc(void *baseAdr, size_t newSize,
                                   const char *filename, int lineno);
 DUMA_EXTERN_C void *_duma_valloc(size_t size, const char *filename, int lineno);
+DUMA_EXTERN_C size_t _duma_malloc_usable_size(void *ptr, const char *filename,
+                                              int lineno);
 DUMA_EXTERN_C char *_duma_strdup(const char *str, const char *filename,
                                  int lineno);
 DUMA_EXTERN_C void *_duma_memcpy(void *dest, const void *src, size_t size,
@@ -294,6 +296,7 @@ DUMA_EXTERN_C int _duma_posix_memalign(void **memptr, size_t alignment,
                                        size_t userSize);
 DUMA_EXTERN_C void *_duma_realloc(void *baseAdr, size_t newSize);
 DUMA_EXTERN_C void *_duma_valloc(size_t size);
+DUMA_EXTERN_C size_t _duma_malloc_usable_size(void *ptr);
 DUMA_EXTERN_C char *_duma_strdup(const char *str);
 DUMA_EXTERN_C void *_duma_memcpy(void *dest, const void *src, size_t size);
 DUMA_EXTERN_C void *_duma_memmove(void *dest, const void *src, size_t size);
@@ -318,6 +321,8 @@ DUMA_EXTERN_C char *_duma_strncat(char *dest, const char *src, size_t size);
 #define realloc(BASEADR, NEWSIZE)                                              \
   _duma_realloc(BASEADR, NEWSIZE, __FILE__, __LINE__)
 #define valloc(SIZE) _duma_valloc(SIZE, __FILE__, __LINE__)
+#define malloc_usable_size(PTR) \
+  _duma_malloc_usable_size(PTR, __FILE__, __LINE__)
 #define strdup(STR) _duma_strdup(STR, __FILE__, __LINE__)
 #define memcpy(DEST, SRC, SIZE)                                                \
   _duma_memcpy(DEST, SRC, SIZE, __FILE__, __LINE__)

--- a/dumadll/dumadll.cpp
+++ b/dumadll/dumadll.cpp
@@ -46,6 +46,12 @@ void * duma_valloc(size_t size)
 }
 
 
+size_t duma_malloc_usable_size(void *ptr)
+{
+  return _duma_malloc_usable_size(ptr  DUMA_PARAMS_UK);
+}
+
+
 char * duma_strdup(const char * str)
 {
   return _duma_strdup(str  DUMA_PARAMS_UK);

--- a/dumadll/dumadll.def
+++ b/dumadll/dumadll.def
@@ -7,6 +7,7 @@ EXPORTS
   duma_memalign
   duma_realloc
   duma_valloc
+  duma_malloc_usable_size
   duma_strdup
   duma_memcpy
   duma_memmove

--- a/noduma.h
+++ b/noduma.h
@@ -77,6 +77,10 @@
 #undef valloc
 #endif
 
+#ifdef malloc_usable_size
+#undef malloc_usable_size
+#endif
+
 #ifdef strdup
 #undef strdup
 #endif


### PR DESCRIPTION
malloc_usable_size returns the size of the allocated chunk. We must provide our own implementation as the size we allocated differs from what libc would allocate.