### PR TITLE
Update minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(DUMA C CXX)
 
 # See README.md for help building and using DUMA

--- a/confdir/CMakeLists.txt
+++ b/confdir/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(DUMA_CONF)
 
 # See README.md for help building and using DUMA


### PR DESCRIPTION
Versions below 3.5 are no longer supported by CMake 4.0+, so either the users should explicitly request it via specifying CMAKE_POLICY_VERSION_MINIMUM, or the libraries should update their CMakeLists.txt files. We can't use the `<min>...<max>` syntax yet, as it's supported since the version 3.12.

See
cmake.org/cmake/help/v4.0/release/4.0.html
cmake.org/cmake/help/latest/command/cmake_minimum_required.html